### PR TITLE
Add `prettier-plugin-motoko` to open repositories

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -29,6 +29,7 @@ motoko
 motoko-base
 motoko-playground
 portal
+prettier-plugin-motoko
 quill
 rules_motoko
 sdk


### PR DESCRIPTION
As mentioned in the readme since [August 2022](https://github.com/dfinity/prettier-plugin-motoko/commit/096a6c92df43a2f27de6cd4c3d57c74bb0ade0ca), the [prettier-plugin-motoko](https://github.com/dfinity/prettier-plugin-motoko) repository was originally supposed to allow community contributions. 

Let me know if it would be necessary to open a corresponding JIRA ticket. Thanks!
