### PR TITLE
add workflow for new repo

### DIFF
--- a/.github/actions/get_repo_name/action.yml
+++ b/.github/actions/get_repo_name/action.yml
@@ -16,7 +16,7 @@ runs:
       - name: Get repo name
         id: get-repo-name
         run: |
-          NEW_REPO=$(git diff origin/master...HEAD open-repositories.txt | grep "^+[a-zA-Z]" | sed 's/+//')
+          NEW_REPO=$(git diff origin/master...HEAD open-repositories.txt | grep "^+[a-zA-Z]" | sed 's/+//' || echo "")
           if [ "$NEW_REPO" = "" ]; then
             echo "No repository added."
             exit 0

--- a/.github/actions/get_repo_name/action.yml
+++ b/.github/actions/get_repo_name/action.yml
@@ -4,6 +4,9 @@ outputs:
   repo-name:
     value: ${{ steps.get-repo-name.outputs.new_repo }}
     description: "The name of the repository that was added."
+  new_repo_added:
+    value: ${{ steps.get-repo-name.outputs.new_repo_added }}
+    description: "Boolean if a new repo was added."
 
 runs:
   using: 'composite'

--- a/.github/actions/get_repo_name/action.yml
+++ b/.github/actions/get_repo_name/action.yml
@@ -18,10 +18,10 @@ runs:
         run: |
           NEW_REPO=$(git diff origin/master...HEAD open-repositories.txt | grep "^+[a-zA-Z]" | sed 's/+//')
           REPO_COUNT=$(echo "$NEW_REPO" | wc -l)
-          if [ $REPO_COUNT > 1 ]; then
+          if (( $REPO_COUNT > 1 )); then
             echo "Only one repository can be added at a time. Please create separate PRs."
             exit 1
-          elif [ $REPO_COUNT = 0 ]; then
+          elif (( $REPO_COUNT = 0 )); then
             echo "No new repository found. Please check the open-repositories.txt file again."
             exit 1
           else

--- a/.github/actions/get_repo_name/action.yml
+++ b/.github/actions/get_repo_name/action.yml
@@ -17,6 +17,10 @@ runs:
         id: get-repo-name
         run: |
           NEW_REPO=$(git diff origin/master...HEAD open-repositories.txt | grep "^+[a-zA-Z]" | sed 's/+//')
+          if [ "$NEW_REPO" = "" ]; then
+            echo "No repository added."
+            exit 0
+          fi
           REPO_COUNT=$(echo "$NEW_REPO" | wc -l)
           if (( $REPO_COUNT > 1 )); then
             echo "Only one repository can be added at a time. Please create separate PRs."
@@ -24,6 +28,5 @@ runs:
           elif (( $REPO_COUNT = 1 )); then
             echo "new_repo=$NEW_REPO" >> $GITHUB_OUTPUT
             echo "new_repo_added=true" >> $GITHUB_OUTPUT
-
           fi
         shell: bash

--- a/.github/actions/get_repo_name/action.yml
+++ b/.github/actions/get_repo_name/action.yml
@@ -16,6 +16,15 @@ runs:
       - name: Get repo name
         id: get-repo-name
         run: |
-          NEW_REPO=$(git diff origin/master...HEAD open-repositories.txt | grep "+" | tail -n 1 | sed 's/+//')
-          echo "new_repo=$NEW_REPO" >> $GITHUB_OUTPUT
+          NEW_REPO=$(git diff origin/master...HEAD open-repositories.txt | grep "^+[a-z]" | sed 's/+//')
+          REPO_COUNT=$(echo "$NEW_REPO" | wc -l)
+          if [ $REPO_COUNT > 1 ]; then
+            echo "Only one repository can be added at a time. Please create separate PRs."
+            exit 1
+          elif [ $REPO_COUNT = 0 ]; then
+            echo "No new repository found. Please check the open-repositories.txt file again."
+            exit 1
+          else
+            echo "new_repo=$NEW_REPO" >> $GITHUB_OUTPUT
+          fi
         shell: bash

--- a/.github/actions/get_repo_name/action.yml
+++ b/.github/actions/get_repo_name/action.yml
@@ -16,7 +16,7 @@ runs:
       - name: Get repo name
         id: get-repo-name
         run: |
-          NEW_REPO=$(git diff origin/master...HEAD open-repositories.txt | grep "^+[a-z]" | sed 's/+//')
+          NEW_REPO=$(git diff origin/master...HEAD open-repositories.txt | grep "^+[a-zA-Z]" | sed 's/+//')
           REPO_COUNT=$(echo "$NEW_REPO" | wc -l)
           if [ $REPO_COUNT > 1 ]; then
             echo "Only one repository can be added at a time. Please create separate PRs."

--- a/.github/actions/get_repo_name/action.yml
+++ b/.github/actions/get_repo_name/action.yml
@@ -1,0 +1,21 @@
+name: 'Get Repo Name'
+description: 'Gets the repository name that was added to the open-repositories.txt file.'
+outputs:
+  repo-name:
+    value: ${{ steps.get-repo-name.outputs.new_repo }}
+    description: "The name of the repository that was added."
+
+runs:
+  using: 'composite'
+  steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get repo name
+        id: get-repo-name
+        run: |
+          NEW_REPO=$(git diff origin/master...HEAD open-repositories.txt | grep "+" | tail -n 1 | sed 's/+//')
+          echo "new_repo=$NEW_REPO" >> $GITHUB_OUTPUT
+        shell: bash

--- a/.github/actions/get_repo_name/action.yml
+++ b/.github/actions/get_repo_name/action.yml
@@ -25,10 +25,10 @@ runs:
             exit 0
           fi
           REPO_COUNT=$(echo "$NEW_REPO" | wc -l)
-          if (( $REPO_COUNT > 1 )); then
+          if (( REPO_COUNT > 1 )); then
             echo "Only one repository can be added at a time. Please create separate PRs."
             exit 1
-          elif (( $REPO_COUNT = 1 )); then
+          elif (( REPO_COUNT = 1 )); then
             echo "new_repo=$NEW_REPO" >> $GITHUB_OUTPUT
             echo "new_repo_added=true" >> $GITHUB_OUTPUT
           fi

--- a/.github/actions/get_repo_name/action.yml
+++ b/.github/actions/get_repo_name/action.yml
@@ -21,10 +21,9 @@ runs:
           if (( $REPO_COUNT > 1 )); then
             echo "Only one repository can be added at a time. Please create separate PRs."
             exit 1
-          elif (( $REPO_COUNT = 0 )); then
-            echo "No new repository found. Please check the open-repositories.txt file again."
-            exit 1
-          else
+          elif (( $REPO_COUNT = 1 )); then
             echo "new_repo=$NEW_REPO" >> $GITHUB_OUTPUT
+            echo "new_repo_added=true" >> $GITHUB_OUTPUT
+
           fi
         shell: bash

--- a/.github/workflows/check_new_repo.yml
+++ b/.github/workflows/check_new_repo.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Check if repository is compliant
         id:  check-compliance
+        if: steps.get-repo-name.outputs.new_repo_added == 'true'
         uses: ./.github/actions/check_compliance/
         with:
           repo-name: ${{ steps.get-repo-name.outputs.repo-name }}

--- a/.github/workflows/check_new_repo.yml
+++ b/.github/workflows/check_new_repo.yml
@@ -1,0 +1,70 @@
+# Workflow to check if a new repository has been added to list and is compliant
+# This workflow is only run inside the repositories-open-to-contributions repository
+
+name: Check New Repo
+
+on:
+  pull_request:
+    paths:
+      - open-repositories.txt
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  check-repo-compliance:
+    name: Check if repository is compliant
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get repo name
+        id: get-repo-name
+        uses:  ./.github/actions/get_repo_name/
+
+      - name: Check if repository is compliant
+        id:  check-compliance
+        uses: ./.github/actions/check_compliance/
+        with:
+          repo-name: ${{ steps.get-repo-name.outputs.repo-name }}
+
+      - name: Has README
+        id: has-readme
+        run: |
+          if [ "${{ steps.check-compliance.outputs.has_readme }}" = "False" ]; then
+            echo "Repo is not compliant - missing README"
+            exit 1
+          else
+            exit 0
+          fi
+
+      - name: Has Codeowners file
+        id: has-codeowners
+        run: |
+          if [ "${{ steps.check-compliance.outputs.has_codeowners }}" = "False" ]; then
+            echo "Repo is not compliant - missing Codeowners file"
+            exit 1
+          else
+            exit 0
+          fi
+
+      - name: Has License file
+        id:  has-license
+        run: |
+          if [ "${{ steps.check-compliance.outputs.has_license }}" = "False" ]; then
+            echo "Repo is not compliant - missing License file"
+            exit 1
+          else
+             exit 0
+          fi
+
+      - name: Is branch protected
+        id: is-branch-protected
+        run: |
+          if [ "${{ steps.check-compliance.outputs.is_branch_protected }}" = "False" ]; then
+            echo "Repo is not compliant - is not branch protected"
+            exit 1
+          else
+            exit 0
+          fi

--- a/.github/workflows/check_new_repo.yml
+++ b/.github/workflows/check_new_repo.yml
@@ -32,39 +32,31 @@ jobs:
       - name: Has README
         id: has-readme
         run: |
-          if [ "${{ steps.check-compliance.outputs.has_readme }}" = "False" ]; then
+          if [ "${{ steps.check-compliance.outputs.has_readme }}" != "True" ]; then
             echo "Repo is not compliant - missing README"
             exit 1
-          else
-            exit 0
           fi
 
       - name: Has Codeowners file
         id: has-codeowners
         run: |
-          if [ "${{ steps.check-compliance.outputs.has_codeowners }}" = "False" ]; then
+          if [ "${{ steps.check-compliance.outputs.has_codeowners }}" != "True" ]; then
             echo "Repo is not compliant - missing Codeowners file"
             exit 1
-          else
-            exit 0
           fi
 
       - name: Has License file
         id:  has-license
         run: |
-          if [ "${{ steps.check-compliance.outputs.has_license }}" = "False" ]; then
+          if [ "${{ steps.check-compliance.outputs.has_license }}" != "True" ]; then
             echo "Repo is not compliant - missing License file"
             exit 1
-          else
-             exit 0
           fi
 
       - name: Is branch protected
         id: is-branch-protected
         run: |
-          if [ "${{ steps.check-compliance.outputs.is_branch_protected }}" = "False" ]; then
+          if [ "${{ steps.check-compliance.outputs.is_branch_protected }}" != "True" ]; then
             echo "Repo is not compliant - is not branch protected"
             exit 1
-          else
-            exit 0
           fi

--- a/.github/workflows/check_new_repo.yml
+++ b/.github/workflows/check_new_repo.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Has README
         id: has-readme
+        if: steps.get-repo-name.outputs.new_repo_added == 'true'
         run: |
           if [ "${{ steps.check-compliance.outputs.has_readme }}" != "True" ]; then
             echo "Repo is not compliant - missing README"
@@ -39,6 +40,7 @@ jobs:
 
       - name: Has Codeowners file
         id: has-codeowners
+        if: steps.get-repo-name.outputs.new_repo_added == 'true'
         run: |
           if [ "${{ steps.check-compliance.outputs.has_codeowners }}" != "True" ]; then
             echo "Repo is not compliant - missing Codeowners file"
@@ -46,6 +48,7 @@ jobs:
           fi
 
       - name: Has License file
+        if: steps.get-repo-name.outputs.new_repo_added == 'true'
         id:  has-license
         run: |
           if [ "${{ steps.check-compliance.outputs.has_license }}" != "True" ]; then
@@ -54,6 +57,7 @@ jobs:
           fi
 
       - name: Is branch protected
+        if: steps.get-repo-name.outputs.new_repo_added == 'true'
         id: is-branch-protected
         run: |
           if [ "${{ steps.check-compliance.outputs.is_branch_protected }}" != "True" ]; then

--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -34,6 +34,7 @@ quill
 rules_motoko
 sdk
 stable-structures
+TEST
 test-state-machine-client
 vessel
 vessel-package-set

--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -34,7 +34,6 @@ quill
 rules_motoko
 sdk
 stable-structures
-TEST
 test-state-machine-client
 vessel
 vessel-package-set


### PR DESCRIPTION
This workflow will only run in the current repository and check if any repositories added to the list meet the compliance checks. It does this by checking the most recent commit changes to `open-repositories.txt` file.

For a demo of how the workflow is activated, see the following PR: https://github.com/dfinity/repositories-open-to-contributions/pull/35