### PR TITLE
use github3 package instead of github

### DIFF
--- a/.github/actions/check_external_contrib/action.yml
+++ b/.github/actions/check_external_contrib/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "The name of the repository"
     default: ${{github.event.repository.name}}
     required: false
+  github-token:
+    description: 'Github token of the repository (automatically created by Github)'
+    default: ${{ github.token }}
+    required: false
 outputs:
   accepts_contrib:
     value: ${{ steps.check-external-contrib.outputs.accepts_contrib }}

--- a/.github/actions/check_external_contrib/action.yml
+++ b/.github/actions/check_external_contrib/action.yml
@@ -30,3 +30,4 @@ runs:
       shell: bash
       env:
         REPO: ${{ inputs.repo-name }}
+        GH_TOKEN: ${{ inputs.github-token }}

--- a/custom_python_actions/check_external_contrib.py
+++ b/custom_python_actions/check_external_contrib.py
@@ -1,46 +1,38 @@
-import base64
 import os
 import time
-from typing import Dict, List, NoReturn, Union
+from typing import List
 
-import requests
+import github3
 
 
-def download_file(url: str) -> Union[Dict, NoReturn]:
-
+def download_gh_file(repo: github3.github.repo, file_path: str) -> str:
     # sometimes the request does not work the first time, so set a retry
     for attempt in range(5):
-        x = requests.get(url)
-        data = x.json()
         try:
-            data["content"]
-            data["encoding"]
+            file_content = repo.file_contents(file_path)
             break
-        except KeyError as error:
+        except ConnectionResetError as error:
             if attempt < 4:
                 time.sleep(3)
                 continue
             else:
                 # if it hasn't succeeded after 5 tries, raise the error
-                raise Exception("Error downloading data. Try rerunning the CI job") from error
-    return data
+                raise Exception(
+                    "Error downloading data. Try rerunning the CI job"
+                ) from error
+
+    file_decoded = file_content.decoded.decode()
+    return file_decoded
 
 
-def decode_file(data: Dict) -> str:
-    file_content = data["content"]
-    if data.get("encoding") == "base64":
-        file_content = base64.b64decode(file_content).decode()
-    return file_content
-
-
-def get_repos_open_to_contributions() -> List[str]:
-    owner = "dfinity"
+def get_repos_open_to_contributions(gh: github3.login) -> List[str]:
+    org = "dfinity"
     repo_name = "repositories-open-to-contributions"
     file_path = "open-repositories.txt"
-    url = f"https://api.github.com/repos/{owner}/{repo_name}/contents/{file_path}"
 
-    data = download_file(url)
-    file_content = decode_file(data)
+    repo = gh.repository(owner=org, repository=repo_name)
+
+    file_content = download_gh_file(repo, file_path)
 
     # convert .txt file to list
     repo_list = file_content.split("\n")
@@ -50,8 +42,11 @@ def get_repos_open_to_contributions() -> List[str]:
 
 def main() -> None:
     repo = os.environ["REPO"]
+    gh_token = os.environ["GH_TOKEN"]
 
-    repo_list = get_repos_open_to_contributions()
+    gh = github3.login(token=gh_token)
+
+    repo_list = get_repos_open_to_contributions(gh)
     accepts_contrib = repo in repo_list
 
     os.system(f"""echo 'accepts_contrib={accepts_contrib}' >> $GITHUB_OUTPUT""")

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,4 @@
 github3.py
-requests
 mypy
 black
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,9 +59,7 @@ pytest==7.2.1
 python-dateutil==2.8.2
     # via github3-py
 requests==2.28.2
-    # via
-    #   -r requirements.in
-    #   github3-py
+    # via github3-py
 six==1.16.0
     # via python-dateutil
 tomli==2.0.1


### PR DESCRIPTION
Instead of using the github api to get the contents of the file `open-reposotories.txt` I discovered that the `github3` python package has the same functionality. This simplifies the code a little and is more consistent with how we interact with github in other modules.