### PR TITLE
Add `experimental-minting-tool` to open repositories

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -13,6 +13,7 @@ conventional-pr-title-action
 dfx-extensions
 examples
 exchange-rate-canister
+experimental-minting-tool
 getting-started
 hardware-wallet-cli
 ic-docutrack


### PR DESCRIPTION
**Overview**
Recently, I've been trying to issue nft following [this YouTube video](https://www.youtube.com/watch?v=1po3udDADp4&t=972s), but the minting-tool referenced by [example/README](https://github.com/dfinity/examples/tree/master/rust/dip721-nft-container#minting) isn't working properly, so I requested PRs.

1. https://github.com/dfinity/examples/pull/485
2. https://github.com/dfinity/experimental-minting-tool/pull/8

In the case of the `example`, my PR was merged, but experimental-tool can't be merged cause of privilage. so request this pr.
