### PR TITLE
Remove capsules from open-repositories

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -7,7 +7,6 @@ bigmap-poc
 cancan
 candid
 canister-profiling
-capsules
 cdk-rs
 conventional-pr-title-action
 dfx-extensions


### PR DESCRIPTION
The repository was never published and now archived.