### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -17,28 +17,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Check if accepting external contributions
-        id: accepts_external_contrib
-        uses:  ./.github/actions/check_external_contrib/
-
       - name: Check Membership
         id:  check-membership
-        if: steps.accepts_external_contrib.outputs.accepts_contrib == 'true'
         uses: ./.github/actions/check_membership/
         with:
           github-token: ${{ secrets.GH_TOKEN_READ_ORG }}
+
+      - name: Check if accepting external contributions
+        id: accepts_external_contrib
+        if: steps.check-membership.outputs.is_member != 'true'
+        uses:  ./.github/actions/check_external_contrib/
 
         # Todo: if repo does not accept external contributions and is not a member, close the PR with a comment
 
       - name: Add Label
         uses: actions-ecosystem/action-add-labels@v1
-        if: steps.check-membership.outputs.is_member == 'false'
+        if: steps.check-membership.outputs.is_member != 'true'
         with:
           labels: external-contributor
 
       - name: Check CLA
         id:  check-cla
         uses: ./.github/actions/check_cla/
-        if: steps.check-membership.outputs.is_member == 'false'
+        if: steps.check-membership.outputs.is_member != 'true'
         with:
           github-token: ${{ secrets.GH_TOKEN_RUN_WORKFLOW }}

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Check CLA
         id:  check-cla
         uses: ./.github/actions/check_cla/
-        if: steps.check-membership.outputs.is_member != 'true'
+        if: steps.check-membership.outputs.is_member == 'false'
         with:
           github-token: ${{ secrets.GH_TOKEN_RUN_WORKFLOW }}


### PR DESCRIPTION
This fixes a bug I didn't notice before. Prior to this change this was the workflow execution:

<img width="366" alt="Screenshot 2023-05-23 at 09 36 43" src="https://github.com/dfinity/repositories-open-to-contributions/assets/47304080/c1df3040-bcb6-43d1-997d-183597fe9641">

Where `Check CLA` was run because there was no output for `is_member`. This change results in the correct execution of the workflow:

<img width="348" alt="Screenshot 2023-05-23 at 09 37 41" src="https://github.com/dfinity/repositories-open-to-contributions/assets/47304080/c289cc5b-9557-4331-8604-1dd7659809e7">
