### PR TITLE
specify repo to check out

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repository: 'repositories-open-to-contributions'
 
       - name: Check Membership
         id:  check-membership

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: 'repositories-open-to-contributions'
+          repository: 'dfinity/repositories-open-to-contributions'
 
       - name: Check Membership
         id:  check-membership


### PR DESCRIPTION
Because this workflow will be used as a required workflow, we need to pass in the repository it needs to check out.