### PR TITLE
Rename secrets

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -23,7 +23,7 @@ jobs:
         id:  check-membership
         uses: ./.github/actions/check_membership/
         with:
-          github-token: ${{ secrets.GH_TOKEN_READ_ORG }}
+          github-token: ${{ secrets.CLA_READ_ORG_MEMBERSHIP }}
 
       - name: Check if accepting external contributions
         id: accepts_external_contrib
@@ -54,4 +54,4 @@ jobs:
         uses: ./.github/actions/check_cla_pr/
         if: steps.check-membership.outputs.is_member != 'true' && steps.accepts_external_contrib.outputs.accepts_contrib != 'false'
         with:
-          github-token: ${{ secrets.GH_TOKEN_COMMENT_ON_PRS }}
+          github-token: ${{ secrets.CLA_COMMENT_ON_PRS }}

--- a/.github/workflows/check_existing_repo.yml
+++ b/.github/workflows/check_existing_repo.yml
@@ -27,4 +27,4 @@ jobs:
         if: steps.accepts_external_contrib.outputs.accepts_contrib == 'true'
         uses: ./.github/actions/check_compliance/
         with:
-          github-token: ${{ secrets.GH_TOKEN_READ_REPO_PERMISSIONS }}
+          github-token: ${{ secrets.COMPLIANCE_READ_REPO_PERMISSIONS }}

--- a/.github/workflows/check_new_repo.yml
+++ b/.github/workflows/check_new_repo.yml
@@ -32,4 +32,4 @@ jobs:
         uses: ./.github/actions/check_compliance/
         with:
           repo-name: ${{ steps.get-repo-name.outputs.repo-name }}
-          github-token: ${{ secrets.GH_TOKEN_READ_ORG }}
+          github-token: ${{ secrets.COMPLIANCE_READ_ORG_MEMBERSHIP }}

--- a/.github/workflows/check_new_repo.yml
+++ b/.github/workflows/check_new_repo.yml
@@ -33,5 +33,3 @@ jobs:
         with:
           repo-name: ${{ steps.get-repo-name.outputs.repo-name }}
           github-token: ${{ secrets.COMPLIANCE_READ_ORG_MEMBERSHIP }}
-
-#test

--- a/.github/workflows/check_new_repo.yml
+++ b/.github/workflows/check_new_repo.yml
@@ -32,4 +32,4 @@ jobs:
         uses: ./.github/actions/check_compliance/
         with:
           repo-name: ${{ steps.get-repo-name.outputs.repo-name }}
-          github-token: ${{ secrets.COMPLIANCE_READ_ORG_MEMBERSHIP }}
+          github-token: ${{ secrets.COMPLIANCE_READ_REPO_PERMISSIONS }}

--- a/.github/workflows/check_new_repo.yml
+++ b/.github/workflows/check_new_repo.yml
@@ -33,3 +33,5 @@ jobs:
         with:
           repo-name: ${{ steps.get-repo-name.outputs.repo-name }}
           github-token: ${{ secrets.COMPLIANCE_READ_ORG_MEMBERSHIP }}
+
+#test

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,7 +8,10 @@ on:
     branches-ignore:
       - integration-test-1
     paths:
-      - .github/**
+      - .github/custom_python_actions/check_compliance.py
+      - .github/custom_python_actions/check_external_contrib.py
+      - .github/tests/test_compliance_checks.py
+      - .github/tests/test_check_external_contrib.py
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,6 +12,8 @@ on:
       - .github/custom_python_actions/check_external_contrib.py
       - .github/tests/test_compliance_checks.py
       - .github/tests/test_check_external_contrib.py
+      - .github/workflows/check_existing_repo.yml
+      - .github/workflows/check_new_repo.yml
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Rename secrets to specify which ones are used for the CLA workflow vs compliance workflow. Will make managing them easier.

Change logic for when integration tests should be run (this one only tests the compliance workflow so there's no point to always run it).