### PR TITLE
remove pull_request trigger

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           repository: 'dfinity/repositories-open-to-contributions'
 
-      - name: Test
-        run: echo "hello"
-
       - name: Check Membership
         id:  check-membership
         uses: ./.github/actions/check_membership/

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check CLA
     runs-on: ubuntu-latest
     # only run on pull_request trigger if the branch is in the repo (i.e. not from a fork)
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request_target.head.repo.full_name == github.repository || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -5,10 +5,11 @@ name: Check CLA
 on:
   # because the cla workflow will run on worflows generated from forks, they do not have access to secrets
   # pull_request_target only runs the workflow on the master branch but allows access to secrets
+
+  # the one downside of this approach is that making changes to the cla workflow itself is more tedious. For development purposes
+  # the cla workflow will need to be manually tested using workflow_dispatch in the actions tab.
   pull_request_target:
     branches: [ master ]
-  pull_request:
-    branches: '**'
   merge_group:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -17,8 +18,6 @@ jobs:
   check-cla:
     name: Check CLA
     runs-on: ubuntu-latest
-    # only run on pull_request trigger if the branch is in the repo (i.e. not from a fork)
-    if: github.event.pull_request_target.head.repo.full_name == github.repository || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           repository: 'dfinity/repositories-open-to-contributions'
 
+      - name: Test
+        run: echo "hello"
+
       - name: Check Membership
         id:  check-membership
         uses: ./.github/actions/check_membership/


### PR DESCRIPTION
Intended behavior was to have the cla workflow triggered by `pull_request` run on internal PRs and `pull_request_target` run on forked PRs, but this adds a lot of complexity and did not work as expected.

The simplest solution is to only use `pull_request_target` which runs on master and manually kick off the workflow (for internal developers) when updates to the cla workflow need to be made and tested.