### PR TITLE
add test-compliant-repository-public

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -42,6 +42,7 @@ response-verification
 rules_motoko
 sdk
 stable-structures
+test-compliant-repository-public
 test-state-machine-client
 threshold
 vessel


### PR DESCRIPTION
Add `test-compliant-repository-public` to accepts-external-contributions list so we can test the CLA workflow for external contributions.