### PR TITLE
add regular pull_request trigger

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -10,6 +10,8 @@ on:
   # the cla workflow will need to be manually tested using workflow_dispatch in the actions tab.
   pull_request_target:
     branches: [ master ]
+  pull_request:
+    branches: '**'
   merge_group:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
I need to test this out a little more, but I think removing this line broke the required workflows for regular internal PRs. It might be necessary to have separate workflows for external and internal contributions, but right now I just want to test if adding these lines back fixes required workflows.