### PR TITLE
Improve error message

### DIFF
--- a/.github/custom_python_actions/check_cla_issue.py
+++ b/.github/custom_python_actions/check_cla_issue.py
@@ -11,7 +11,7 @@ def main() -> None:
 
     gh = github3.login(token=gh_token)
     if not gh:
-        raise Exception("GH_TOKEN not correctly set")
+        raise Exception("github login failed - maybe GH_TOKEN was not correctly set")
 
     issue = gh.issue("dfinity", "cla", issue_id)
     user = issue.title.replace("cla: @", "")

--- a/.github/custom_python_actions/check_cla_issue.py
+++ b/.github/custom_python_actions/check_cla_issue.py
@@ -10,6 +10,9 @@ def main() -> None:
     issue_id = os.environ["ISSUE_ID"]
 
     gh = github3.login(token=gh_token)
+    if not gh:
+        raise Exception("GH_TOKEN not correctly set")
+
     issue = gh.issue("dfinity", "cla", issue_id)
     user = issue.title.replace("cla: @", "")
 

--- a/.github/custom_python_actions/check_cla_pr.py
+++ b/.github/custom_python_actions/check_cla_pr.py
@@ -84,6 +84,9 @@ def main() -> None:
     pr_id = os.environ["PR_ID"]
 
     gh = github3.login(token=gh_token)
+    if not gh:
+        raise Exception("GH_TOKEN not correctly set")
+
     pr = gh.pull_request(org, repo, pr_id)
     user = pr.user.login
 

--- a/.github/custom_python_actions/check_cla_pr.py
+++ b/.github/custom_python_actions/check_cla_pr.py
@@ -85,7 +85,7 @@ def main() -> None:
 
     gh = github3.login(token=gh_token)
     if not gh:
-        raise Exception("GH_TOKEN not correctly set")
+        raise Exception("github login failed - maybe GH_TOKEN was not correctly set")
 
     pr = gh.pull_request(org, repo, pr_id)
     user = pr.user.login

--- a/.github/custom_python_actions/check_compliance.py
+++ b/.github/custom_python_actions/check_compliance.py
@@ -20,7 +20,7 @@ def main() -> None:
 
     gh = github3.login(token=gh_token)
     if not gh:
-        raise Exception("GH_TOKEN not correctly set")
+        raise Exception("github login failed - maybe GH_TOKEN was not correctly set")
 
     try:
         repo = gh.repository(owner=org_name, repository=repo_name)

--- a/.github/custom_python_actions/check_compliance.py
+++ b/.github/custom_python_actions/check_compliance.py
@@ -19,6 +19,9 @@ def main() -> None:
     repo_name = os.environ["REPO"]
 
     gh = github3.login(token=gh_token)
+    if not gh:
+        raise Exception("GH_TOKEN not correctly set")
+
     try:
         repo = gh.repository(owner=org_name, repository=repo_name)
         org = gh.organization(username=org_name)

--- a/.github/custom_python_actions/check_external_contrib.py
+++ b/.github/custom_python_actions/check_external_contrib.py
@@ -27,6 +27,9 @@ def main() -> None:
 
     gh = github3.login(token=gh_token)
 
+    if not gh:
+        raise Exception("GH_TOKEN not correctly set")
+
     repo_list = get_repos_open_to_contributions(gh)
     accepts_contrib = repo in repo_list
 

--- a/.github/custom_python_actions/check_external_contrib.py
+++ b/.github/custom_python_actions/check_external_contrib.py
@@ -28,7 +28,7 @@ def main() -> None:
     gh = github3.login(token=gh_token)
 
     if not gh:
-        raise Exception("GH_TOKEN not correctly set")
+        raise Exception("github login failed - maybe GH_TOKEN was not correctly set")
 
     repo_list = get_repos_open_to_contributions(gh)
     accepts_contrib = repo in repo_list

--- a/.github/custom_python_actions/check_membership.py
+++ b/.github/custom_python_actions/check_membership.py
@@ -18,7 +18,7 @@ def main() -> None:
     gh = github3.login(token=gh_token)
 
     if not gh:
-        raise Exception("GH_TOKEN not correctly set")
+        raise Exception("github login failed - maybe GH_TOKEN was not correctly set")
 
     is_member = is_member_of_org(gh, org, user)
 

--- a/.github/custom_python_actions/check_membership.py
+++ b/.github/custom_python_actions/check_membership.py
@@ -7,11 +7,7 @@ def is_member_of_org(gh: github3.login, org: str, user: str) -> bool:
     """
     Return whether the user is a member of the organisation.
     """
-    try:
-        return gh.organization(org).is_member(user)
-    except Exception as error:
-        print(f"Failed with error: {error}")
-        return False
+    return gh.organization(org).is_member(user)
 
 
 def main() -> None:
@@ -20,6 +16,9 @@ def main() -> None:
     user = os.environ["USER"]
 
     gh = github3.login(token=gh_token)
+
+    if not gh:
+        raise Exception("GH_TOKEN not correctly set")
 
     is_member = is_member_of_org(gh, org, user)
 

--- a/.github/tests/test_check_external_contrib.py
+++ b/.github/tests/test_check_external_contrib.py
@@ -3,12 +3,15 @@ from pathlib import Path
 import sys
 from unittest import mock
 
+import pytest
+
 SCRIPT_DIR = file = f"{Path(__file__).parents[1]}/custom_python_actions/"
 print(SCRIPT_DIR)
 sys.path.append(os.path.dirname(SCRIPT_DIR))
 
 from custom_python_actions.check_external_contrib import (
     get_repos_open_to_contributions,
+    main,
 )  # noqa
 
 
@@ -23,3 +26,34 @@ def test_check_repos_open_to_contributions():
     repo_list = get_repos_open_to_contributions(gh)
 
     assert repo_list == ["one-repo", "another-repo"]
+    gh.repository.assert_called_with(
+        owner="dfinity", repository="repositories-open-to-contributions"
+    )
+
+
+@mock.patch.dict(os.environ, {"REPO": "repo-1", "GH_TOKEN": "token"})
+@mock.patch("github3.login")
+@mock.patch("os.system")
+def test_end_to_end(os_system, github_login_mock):
+    gh = mock.Mock()
+    repo = mock.Mock()
+    gh.repository.return_value = repo
+    file_contents = mock.Mock()
+    file_contents.decoded.decode.return_value = "repo-1\nrepo-2\n"
+    repo.file_contents.return_value = file_contents
+    github_login_mock.return_value = gh
+
+    main()
+
+    os_system.assert_called_with("echo 'accepts_contrib=True' >> $GITHUB_OUTPUT")
+
+
+@mock.patch.dict(os.environ, {"REPO": "my_org", "GH_TOKEN": ""})
+@mock.patch("github3.login")
+def test_github_token_not_passed_in(github_login_mock):
+    github_login_mock.return_value = None
+
+    with pytest.raises(Exception) as exc:
+        main()
+
+    assert str(exc.value) == "GH_TOKEN not correctly set"

--- a/.github/tests/test_check_external_contrib.py
+++ b/.github/tests/test_check_external_contrib.py
@@ -56,4 +56,6 @@ def test_github_token_not_passed_in(github_login_mock):
     with pytest.raises(Exception) as exc:
         main()
 
-    assert str(exc.value) == "GH_TOKEN not correctly set"
+    assert (
+        str(exc.value) == "github login failed - maybe GH_TOKEN was not correctly set"
+    )

--- a/.github/tests/test_cla_issue.py
+++ b/.github/tests/test_cla_issue.py
@@ -1,6 +1,8 @@
 import os
 from unittest import mock
 
+import pytest
+
 from custom_python_actions.check_cla_issue import main
 from custom_python_actions.messages import USER_AGREEMENT_MESSAGE
 
@@ -56,3 +58,14 @@ def test_end_to_end_cla_not_signed(cla_mock, gh_login_mock):
     cla.check_if_cla_signed.assert_called_with(issue, "username")
     cla.comment_on_issue.assert_called_once()
     cla.handle_cla_signed.assert_not_called()
+
+
+@mock.patch.dict(os.environ, {"ISSUE_ID": "1", "GH_TOKEN": ""})
+@mock.patch("github3.login")
+def test_github_token_not_passed_in(github_login_mock):
+    github_login_mock.return_value = None
+
+    with pytest.raises(Exception) as exc:
+        main()
+
+    assert str(exc.value) == "GH_TOKEN not correctly set"

--- a/.github/tests/test_cla_issue.py
+++ b/.github/tests/test_cla_issue.py
@@ -68,4 +68,6 @@ def test_github_token_not_passed_in(github_login_mock):
     with pytest.raises(Exception) as exc:
         main()
 
-    assert str(exc.value) == "GH_TOKEN not correctly set"
+    assert (
+        str(exc.value) == "github login failed - maybe GH_TOKEN was not correctly set"
+    )

--- a/.github/tests/test_cla_pr.py
+++ b/.github/tests/test_cla_pr.py
@@ -281,3 +281,17 @@ def test_end_to_end_cla_signed(cla_mock, gh_login_mock, capfd):
 
     assert out == "CLA has been signed.\n"
     cla.check_if_cla_signed.assert_called_with(issue, "username")
+
+
+@mock.patch.dict(
+    os.environ,
+    {"GH_ORG": "my_org", "GH_TOKEN": "", "REPO": "repo-name", "PR_ID": "1"},
+)
+@mock.patch("github3.login")
+def test_github_token_not_passed_in(github_login_mock):
+    github_login_mock.return_value = None
+
+    with pytest.raises(Exception) as exc:
+        main()
+
+    assert str(exc.value) == "GH_TOKEN not correctly set"

--- a/.github/tests/test_cla_pr.py
+++ b/.github/tests/test_cla_pr.py
@@ -294,4 +294,6 @@ def test_github_token_not_passed_in(github_login_mock):
     with pytest.raises(Exception) as exc:
         main()
 
-    assert str(exc.value) == "GH_TOKEN not correctly set"
+    assert (
+        str(exc.value) == "github login failed - maybe GH_TOKEN was not correctly set"
+    )

--- a/.github/tests/test_membership.py
+++ b/.github/tests/test_membership.py
@@ -56,13 +56,24 @@ def test_end_to_end_is_not_member(os_system, github_login_mock, capfd):
 )
 @mock.patch("github3.login")
 @mock.patch("os.system")
-def test_end_to_end_api_fails(os_system, github_login_mock, capfd):
+def test_end_to_end_api_fails(os_system, github_login_mock):
     gh = mock.Mock()
     gh_org = mock.Mock()
     gh.organization.return_value = gh_org
     gh_org.is_member.side_effect = NotFoundError(mock.Mock())
     github_login_mock.return_value = gh
 
-    main()
+    with pytest.raises(NotFoundError):
+        main()
+        os_system.assert_not_called()
 
-    os_system.assert_called_once_with("echo 'is_member=False' >> $GITHUB_OUTPUT")
+
+@mock.patch.dict(os.environ, {"GH_ORG": "my_org", "GH_TOKEN": "", "USER": "username"})
+@mock.patch("github3.login")
+def test_github_token_not_passed_in(github_login_mock):
+    github_login_mock.return_value = None
+
+    with pytest.raises(Exception) as exc:
+        main()
+
+    assert str(exc.value) == "GH_TOKEN not correctly set"

--- a/.github/tests/test_membership.py
+++ b/.github/tests/test_membership.py
@@ -76,4 +76,6 @@ def test_github_token_not_passed_in(github_login_mock):
     with pytest.raises(Exception) as exc:
         main()
 
-    assert str(exc.value) == "GH_TOKEN not correctly set"
+    assert (
+        str(exc.value) == "github login failed - maybe GH_TOKEN was not correctly set"
+    )

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 sorting/target
 **/__pycache__
+.env/**


### PR DESCRIPTION
Github actions doesn't indicate when a secret doesn't exist, it just passes in an empty env var. We therefore need to have explicit error handling to avoid confusing error messages.