### PR TITLE
Fix pr closing workflow

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check if accepting external contributions
         id: accepts_external_contrib
         if: steps.check-membership.outputs.is_member != 'true'
-        uses:  dfinity/repositories-open-to-contributions//.github/actions/check_external_contrib/
+        uses:  dfinity/repositories-open-to-contributions/.github/actions/check_external_contrib/
 
       - name: Close Pull Request
         id: close_pr

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -26,14 +26,14 @@ jobs:
 
       - name: Check Membership
         id:  check-membership
-        uses: dfinity/repositories-open-to-contributions/.github/actions/check_membership/action.yml@master
+        uses: dfinity/repositories-open-to-contributions/.github/actions/check_membership@master
         with:
           github-token: ${{ secrets.CLA_READ_ORG_MEMBERSHIP }}
 
       - name: Check if accepting external contributions
         id: accepts_external_contrib
         if: steps.check-membership.outputs.is_member != 'true'
-        uses:  dfinity/repositories-open-to-contributions/.github/actions/check_external_contrib/action.yml@master
+        uses:  dfinity/repositories-open-to-contributions/.github/actions/check_external_contrib@master
 
       - name: Close Pull Request
         id: close_pr
@@ -56,7 +56,7 @@ jobs:
 
       - name: Check CLA
         id:  check-cla
-        uses: dfinity/repositories-open-to-contributions/.github/actions/check_cla_pr/action.yml@master
+        uses: dfinity/repositories-open-to-contributions/.github/actions/check_cla_pr@master
         if: steps.check-membership.outputs.is_member != 'true' && steps.accepts_external_contrib.outputs.accepts_contrib != 'false'
         with:
           github-token: ${{ secrets.CLA_COMMENT_ON_PRS }}

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -26,14 +26,14 @@ jobs:
 
       - name: Check Membership
         id:  check-membership
-        uses: dfinity/repositories-open-to-contributions/.github/actions/check_membership/
+        uses: dfinity/repositories-open-to-contributions/.github/actions/check_membership/action.yml@master
         with:
           github-token: ${{ secrets.CLA_READ_ORG_MEMBERSHIP }}
 
       - name: Check if accepting external contributions
         id: accepts_external_contrib
         if: steps.check-membership.outputs.is_member != 'true'
-        uses:  dfinity/repositories-open-to-contributions/.github/actions/check_external_contrib/
+        uses:  dfinity/repositories-open-to-contributions/.github/actions/check_external_contrib/action.yml@master
 
       - name: Close Pull Request
         id: close_pr
@@ -56,7 +56,7 @@ jobs:
 
       - name: Check CLA
         id:  check-cla
-        uses: dfinity/repositories-open-to-contributions/.github/actions/check_cla_pr/
+        uses: dfinity/repositories-open-to-contributions/.github/actions/check_cla_pr/action.yml@master
         if: steps.check-membership.outputs.is_member != 'true' && steps.accepts_external_contrib.outputs.accepts_contrib != 'false'
         with:
           github-token: ${{ secrets.CLA_COMMENT_ON_PRS }}

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -23,19 +23,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          repository: 'dfinity/repositories-open-to-contributions'
 
       - name: Check Membership
         id:  check-membership
-        uses: ./.github/actions/check_membership/
+        uses: dfinity/repositories-open-to-contributions/.github/actions/check_membership/
         with:
           github-token: ${{ secrets.CLA_READ_ORG_MEMBERSHIP }}
 
       - name: Check if accepting external contributions
         id: accepts_external_contrib
         if: steps.check-membership.outputs.is_member != 'true'
-        uses:  ./.github/actions/check_external_contrib/
+        uses:  dfinity/repositories-open-to-contributions//.github/actions/check_external_contrib/
 
       - name: Close Pull Request
         id: close_pr
@@ -58,7 +56,7 @@ jobs:
 
       - name: Check CLA
         id:  check-cla
-        uses: ./.github/actions/check_cla_pr/
+        uses: dfinity/repositories-open-to-contributions/.github/actions/check_cla_pr/
         if: steps.check-membership.outputs.is_member != 'true' && steps.accepts_external_contrib.outputs.accepts_contrib != 'false'
         with:
           github-token: ${{ secrets.CLA_COMMENT_ON_PRS }}


### PR DESCRIPTION
There were some issues where repositories using this required workflow were referencing incorrect PR numbers (those from repositories-open-to-contributions and not the relevant repos). This change ensures that the workflow is run on the external repos and only code for running the actions is used from `repositories-open-to-contributions`.