### PR TITLE
update actor to pull_request opened

### DIFF
--- a/.github/actions/check_membership/action.yml
+++ b/.github/actions/check_membership/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   user:
     description: "The username"
-    default: ${{ github.actor }}
+    default: ${{ github.event.pull_request.user.login }}
     required: false
 outputs:
   is_member:

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -20,7 +20,7 @@ jobs:
   check-cla:
     name: Check CLA
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }} && ${{ github.actor != 'github-actions[bot]' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }} && ${{ github.event.pull_request.user.login != 'github-actions[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
It defaults to whichever actor pushed the most recent commit, but we want the actor who opened the PR.