### PR TITLE
check out different repo for each step in CLA

### DIFF
--- a/.github/actions/check_membership/action.yml
+++ b/.github/actions/check_membership/action.yml
@@ -31,9 +31,8 @@ runs:
     - name: Check Membership
       id: check-membership
       run: |
-        python_file=$(curl https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/.github/custom_python_actions/check_membership.py)
-        cat $python_file
-        python $python_file
+        curl -o check_membership.py https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/.github/custom_python_actions/check_membership.py
+        python check_membership.py
       shell: bash
       env:
         GH_ORG: ${{ inputs.org }}

--- a/.github/actions/check_membership/action.yml
+++ b/.github/actions/check_membership/action.yml
@@ -26,11 +26,11 @@ runs:
       with:
         python-version: '3.10'
     - name: Install Dependencies
-      run: pip install -q -r requirements.txt
+      run: pip install -q -r https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/requirements.txt
       shell: bash
     - name: Check Membership
       id: check-membership
-      run: python .github/custom_python_actions/check_membership.py
+      run: python https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/.github/custom_python_actions/check_membership.py
       shell: bash
       env:
         GH_ORG: ${{ inputs.org }}

--- a/.github/actions/check_membership/action.yml
+++ b/.github/actions/check_membership/action.yml
@@ -26,13 +26,12 @@ runs:
       with:
         python-version: '3.10'
     - name: Install Dependencies
-      run: pip install -q -r https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/requirements.txt
+      run: pip install -q -r requirements.txt
       shell: bash
     - name: Check Membership
       id: check-membership
       run: |
-        curl -o check_membership.py https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/.github/custom_python_actions/check_membership.py
-        python check_membership.py
+        python .github/custom_python_actions/check_membership.py
       shell: bash
       env:
         GH_ORG: ${{ inputs.org }}

--- a/.github/actions/check_membership/action.yml
+++ b/.github/actions/check_membership/action.yml
@@ -30,7 +30,7 @@ runs:
       shell: bash
     - name: Check Membership
       id: check-membership
-      run: python https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/check_membership.py
+      run: python https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/.github/custom_python_actions/check_membership.py
       shell: bash
       env:
         GH_ORG: ${{ inputs.org }}

--- a/.github/actions/check_membership/action.yml
+++ b/.github/actions/check_membership/action.yml
@@ -32,6 +32,7 @@ runs:
       id: check-membership
       run: |
         python_file=$(curl https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/.github/custom_python_actions/check_membership.py)
+        cat $python_file
         python $python_file
       shell: bash
       env:

--- a/.github/actions/check_membership/action.yml
+++ b/.github/actions/check_membership/action.yml
@@ -26,11 +26,11 @@ runs:
       with:
         python-version: '3.10'
     - name: Install Dependencies
-      run: pip install -q -r https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/requirements.txt
+      run: pip install -q -r https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/requirements.txt
       shell: bash
     - name: Check Membership
       id: check-membership
-      run: python https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/.github/custom_python_actions/check_membership.py
+      run: python https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/check_membership.py
       shell: bash
       env:
         GH_ORG: ${{ inputs.org }}

--- a/.github/actions/check_membership/action.yml
+++ b/.github/actions/check_membership/action.yml
@@ -30,7 +30,9 @@ runs:
       shell: bash
     - name: Check Membership
       id: check-membership
-      run: python https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/.github/custom_python_actions/check_membership.py
+      run: |
+        python_file=$(curl https://raw.githubusercontent.com/dfinity/repositories-open-to-contributions/master/.github/custom_python_actions/check_membership.py)
+        python $python_file
       shell: bash
       env:
         GH_ORG: ${{ inputs.org }}

--- a/.github/actions/check_membership/action.yml
+++ b/.github/actions/check_membership/action.yml
@@ -30,8 +30,7 @@ runs:
       shell: bash
     - name: Check Membership
       id: check-membership
-      run: |
-        python .github/custom_python_actions/check_membership.py
+      run: python .github/custom_python_actions/check_membership.py
       shell: bash
       env:
         GH_ORG: ${{ inputs.org }}

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: 'dfinity/repositories-open-to-contributions'
+          repository: dfinity/repositories-open-to-contributions
 
       - name: Check Membership
         id:  check-membership

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -25,21 +25,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: dfinity/repositories-open-to-contributions@master
+          repository: 'dfinity/repositories-open-to-contributions'
 
       - name: Check Membership
         id:  check-membership
-        uses: .github/actions/check_membership/
+        uses: ./.github/actions/check_membership/
         with:
           github-token: ${{ secrets.CLA_READ_ORG_MEMBERSHIP }}
 
       - name: Check if accepting external contributions
         id: accepts_external_contrib
         if: steps.check-membership.outputs.is_member != 'true'
-        uses:  .github/actions/check_external_contrib/
+        uses: ./.github/actions/check_external_contrib/
 
-      # - name: Checkout
-      #   uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Close Pull Request
         id: close_pr
@@ -60,14 +60,14 @@ jobs:
         with:
           labels: external-contributor
 
-      # - name: Checkout
-      #   uses: actions/checkout@v3
-      #   with:
-      #     repository: 'dfinity/repositories-open-to-contributions'
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: 'dfinity/repositories-open-to-contributions'
 
       - name: Check CLA
         id:  check-cla
-        uses: .github/actions/check_cla_pr/
+        uses: ./.github/actions/check_cla_pr/
         if: steps.check-membership.outputs.is_member != 'true' && steps.accepts_external_contrib.outputs.accepts_contrib != 'false'
         with:
           github-token: ${{ secrets.CLA_COMMENT_ON_PRS }}

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -24,17 +24,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repository: 'repositories-open-to-contributions'
 
       - name: Check Membership
         id:  check-membership
-        uses: dfinity/repositories-open-to-contributions/.github/actions/check_membership@point-to-files-in-external-repo
+        uses: .github/actions/check_membership/
         with:
           github-token: ${{ secrets.CLA_READ_ORG_MEMBERSHIP }}
 
       - name: Check if accepting external contributions
         id: accepts_external_contrib
         if: steps.check-membership.outputs.is_member != 'true'
-        uses:  dfinity/repositories-open-to-contributions/.github/actions/check_external_contrib@master
+        uses:  .github/actions/check_external_contrib/
+
+      - name: Checkout
+        uses: actions/checkout@v3
 
       - name: Close Pull Request
         id: close_pr
@@ -55,9 +60,14 @@ jobs:
         with:
           labels: external-contributor
 
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: 'repositories-open-to-contributions'
+
       - name: Check CLA
         id:  check-cla
-        uses: dfinity/repositories-open-to-contributions/.github/actions/check_cla_pr@master
+        uses: .github/actions/check_cla_pr/
         if: steps.check-membership.outputs.is_member != 'true' && steps.accepts_external_contrib.outputs.accepts_contrib != 'false'
         with:
           github-token: ${{ secrets.CLA_COMMENT_ON_PRS }}

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: 'repositories-open-to-contributions'
+          repository: 'dfinity/repositories-open-to-contributions@master'
 
       - name: Check Membership
         id:  check-membership
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: 'repositories-open-to-contributions'
+          repository: 'dfinity/repositories-open-to-contributions@master'
 
       - name: Check CLA
         id:  check-cla

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: dfinity/repositories-open-to-contributions
+          repository: dfinity/repositories-open-to-contributions@master
 
       - name: Check Membership
         id:  check-membership

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check Membership
         id:  check-membership
-        uses: dfinity/repositories-open-to-contributions/.github/actions/check_membership@master
+        uses: dfinity/repositories-open-to-contributions/.github/actions/check_membership@point-to-files-in-external-repo
         with:
           github-token: ${{ secrets.CLA_READ_ORG_MEMBERSHIP }}
 

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: 'dfinity/repositories-open-to-contributions@master'
+          repository: 'dfinity/repositories-open-to-contributions'
 
       - name: Check Membership
         id:  check-membership
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          repository: 'dfinity/repositories-open-to-contributions@master'
+          repository: 'dfinity/repositories-open-to-contributions'
 
       - name: Check CLA
         id:  check-cla

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -38,8 +38,8 @@ jobs:
         if: steps.check-membership.outputs.is_member != 'true'
         uses:  .github/actions/check_external_contrib/
 
-      - name: Checkout
-        uses: actions/checkout@v3
+      # - name: Checkout
+      #   uses: actions/checkout@v3
 
       - name: Close Pull Request
         id: close_pr
@@ -60,10 +60,10 @@ jobs:
         with:
           labels: external-contributor
 
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          repository: 'dfinity/repositories-open-to-contributions'
+      # - name: Checkout
+      #   uses: actions/checkout@v3
+      #   with:
+      #     repository: 'dfinity/repositories-open-to-contributions'
 
       - name: Check CLA
         id:  check-cla


### PR DESCRIPTION
Unfortunately this is a little more complicated. For the custom actions we need to check out `repositories-open-to-contributions` since it also needs to run custom python scripts it won't have access to otherwise. But for closing the PR we need to check out the repository where the PR needs to be closed. I will need to test this out a little more.