### PR TITLE
break into separate jobs

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -10,8 +10,6 @@ on:
   # the cla workflow will need to be manually tested using workflow_dispatch in the actions tab.
   pull_request_target:
     branches: [ master ]
-  pull_request:
-    branches: '**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -1,6 +1,6 @@
 # Workflow to check if a user is eligible to contribute or needs to sign the CLA
 
-name: Check CLA
+name: CLA Check
 
 on:
   # because the cla workflow will run on worflows generated from forks, they do not have access to secrets
@@ -16,10 +16,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  check-cla:
-    name: Check CLA
+  check-membership:
+    name: Check Membership
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'github-actions[bot]' }}
+    outputs:
+      is_member: ${{ steps.check-membership.outputs.is_member}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,9 +34,14 @@ jobs:
         with:
           github-token: ${{ secrets.CLA_READ_ORG_MEMBERSHIP }}
 
+  check-external-contributions:
+    name: Check External Contributions
+    runs-on: ubuntu-latest
+    needs: check-membership
+    if: ${{ needs.check-membership.outputs.is_member != 'true' && needs.check-membership.conclusion == 'success' }}
+    steps:
       - name: Check if accepting external contributions
         id: accepts_external_contrib
-        if: steps.check-membership.outputs.is_member != 'true'
         uses: ./.github/actions/check_external_contrib/
 
       - name: Checkout
@@ -42,7 +49,7 @@ jobs:
 
       - name: Close Pull Request
         id: close_pr
-        if: steps.check-membership.outputs.is_member != 'true' && steps.accepts_external_contrib.outputs.accepts_contrib != 'true'
+        if: ${{ steps.accepts_external_contrib.outputs.accepts_contrib != 'true' }}
         run: |
           message="This repository does not accept external contributions yet.
 
@@ -55,18 +62,19 @@ jobs:
 
       - name: Add Label
         uses: actions-ecosystem/action-add-labels@v1
-        if: steps.check-membership.outputs.is_member != 'true' && steps.accepts_external_contrib.outputs.accepts_contrib != 'false'
+        if: ${{ steps.accepts_external_contrib.outputs.accepts_contrib != 'false' }}
         with:
           labels: external-contributor
 
       - name: Checkout
         uses: actions/checkout@v3
+        if: ${{ steps.accepts_external_contrib.outputs.accepts_contrib != 'false' }}
         with:
           repository: 'dfinity/repositories-open-to-contributions'
 
       - name: Check CLA
         id:  check-cla
         uses: ./.github/actions/check_cla_pr/
-        if: steps.check-membership.outputs.is_member != 'true' && steps.accepts_external_contrib.outputs.accepts_contrib != 'false'
+        if: ${{ steps.accepts_external_contrib.outputs.accepts_contrib != 'false' }}
         with:
           github-token: ${{ secrets.CLA_COMMENT_ON_PRS }}


### PR DESCRIPTION
It's a little more intuitive for this to be too separate jobs:
1) Check membership of the contributor
2) Workflow for external contributors

It also simplifies the conditional if logic.