### PR TITLE
CLA workflow has to run in the merge queue.

### DIFF
--- a/.github/workflows/check_cla.yml
+++ b/.github/workflows/check_cla.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - 'master'
       - 'main'
+  # Workflows that are in required checks have to run in merge queue.
+  # Otherwise their status is not reported and merge fails:
+  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
+  merge_group:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Otherwise it's status is not reported and merge fails: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions