### PR TITLE
remove test-compliant-repository-public

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -46,7 +46,6 @@ rules_motoko
 sdk
 setup-dfx
 stable-structures
-test-compliant-repository-public
 test-state-machine-client
 threshold
 vessel


### PR DESCRIPTION
Need to test something and temporarily disable external contributions - this repo is only used for internal testing.