### PR TITLE
feat: [IC-1636] Adding the cycles ledger repository

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -10,6 +10,7 @@ canister-profiling
 cdk-rs
 cns
 conventional-pr-title-action
+cycles-ledger
 decentralization
 dfn-components
 dfx-extensions


### PR DESCRIPTION
We'd like to open up the [cycles ledger repository](https://github.com/dfinity/cycles-ledger) for external contributions.