### PR TITLE
Revert "mark 'bench' repo open to external contributions"

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -3,7 +3,6 @@ ICRC-1
 agent-js
 agent-rs
 awesome-internet-computer
-bench
 bigmap-poc
 cancan
 candid


### PR DESCRIPTION
Reverts dfinity/repositories-open-to-contributions#352

My apologies @ielashi, I didn't realize this hadn't been published yet. Accepting external contributions should be done after the repo has gone through the review process. 