### PR TITLE
Add evm-rpc-canister repository

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -18,6 +18,7 @@ decentralization
 dfn-components
 dfx-extensions
 dfxvm
+evm-rpc-canister
 examples
 exchange-rate-canister
 experimental-minting-tool


### PR DESCRIPTION
The EVM RPC canister repository was initially open to external contributions, which was lost when it was moved from the Github [Internet Computer Protocol](https://github.com/internet-computer-protocol) organization to the Github [DFINITY](https://github.com/dfinity) organization. This should re-enable external contributions.