### PR TITLE
chore(IDX): remove branch protections check

### DIFF
--- a/.github/custom_python_actions/check_compliance.py
+++ b/.github/custom_python_actions/check_compliance.py
@@ -4,7 +4,6 @@ import sys
 import github3
 
 from compliance_checks import (
-    BranchProtection,
     ComplianceCheckHelper,
     CodeOwners,
     License,
@@ -32,7 +31,6 @@ def main() -> None:
 
     checks_passed = True
     for compliance_check in [
-        BranchProtection(),
         CodeOwners(),
         License(),
         Readme(),

--- a/.github/custom_python_actions/compliance_checks.py
+++ b/.github/custom_python_actions/compliance_checks.py
@@ -120,19 +120,6 @@ class RepoPermissions(ComplianceCheck):
 
 
 @dataclass
-class BranchProtection(ComplianceCheck):
-    name: str = "branch_protection"
-    succeeds: bool = False
-    message: Optional[str] = None
-
-    def check(self, helper: ComplianceCheckHelper):
-        repo = helper.repo
-        branch = repo.branch(repo.default_branch)
-
-        self.succeeds = branch.protected
-
-
-@dataclass
 class License(ComplianceCheck):
     name: str = "license"
     succeeds: bool = False

--- a/.github/tests/test_compliance_checks.py
+++ b/.github/tests/test_compliance_checks.py
@@ -6,7 +6,6 @@ import pytest
 from github3.exceptions import NotFoundError
 
 from custom_python_actions.compliance_checks import (
-    BranchProtection,
     CodeOwners,
     ComplianceCheckHelper,
     get_code_owners,
@@ -156,37 +155,6 @@ def test_check_code_owners_fails_other_error():
 
     assert code_owners_check.succeeds == False
     assert code_owners_check.message == "Raised error: some other error"
-
-
-def test_branch_protection_enabled():
-    helper = mock.Mock()
-    repo = mock.Mock()
-    repo.default_branch = "main"
-    branch = mock.Mock()
-    branch.protected = True
-    helper.repo.branch.return_value = branch
-    branch_protection_check = BranchProtection()
-
-    branch_protection_check.check(helper)
-
-    assert repo.branch.called_with("main")
-    assert branch_protection_check.name == "branch_protection"
-    assert branch_protection_check.succeeds == True
-
-
-def test_branch_protection_disabled():
-    helper = mock.Mock()
-    repo = mock.Mock()
-    repo.default_branch = "main"
-    branch = mock.Mock()
-    branch.protected = False
-    helper.repo.branch.return_value = branch
-    branch_protection_check = BranchProtection()
-
-    branch_protection_check.check(helper)
-
-    assert repo.branch.called_with("main")
-    assert branch_protection_check.succeeds == False
 
 
 def test_check_license_exists():


### PR DESCRIPTION
Now that we have branch protections enabled by default on the `dfinity` org we don't need to check for them anymore. This will eliminate any potential errors when they have been configured by rulesets instead of traditional branch protections.