### PR TITLE
Replace `new-motoko-base` with `motoko-core`

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -49,10 +49,10 @@ metrics-encoder
 metrics-proxy
 motoko
 motoko-base
+motoko-core
 motoko-dev-server
 motoko-playground
 motoko.rs
-new-motoko-base
 node-motoko
 nodeprovider-scripts
 pic-js


### PR DESCRIPTION
The `new-motoko-base` repository was recently renamed to `motoko-core`. 