### PR TITLE
chore: CRP-2885 Add motoko-bitcoin

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -49,6 +49,7 @@ metrics-encoder
 metrics-proxy
 motoko
 motoko-base
+motoko-bitcoin
 motoko-core
 motoko-dev-server
 motoko-playground


### PR DESCRIPTION
For context: the repository is already open sourced but we'd like to allow contributors