### PR TITLE
Update open-repositories.txt

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -1,6 +1,5 @@
 ICRC
 ICRC-1
-agent-js
 agent-rs
 awesome-internet-computer
 bigmap-poc
@@ -42,6 +41,7 @@ icx-proxy
 idl2json
 interface-spec
 internet-identity-playwright
+icp-sdk-js-core
 journald-parser
 keysmith
 linkedup

--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -37,11 +37,11 @@ ic-repl
 ic-staking-documentation
 ic-wasm
 ic-websocket-poc
+icp-sdk-js-core
 icx-proxy
 idl2json
 interface-spec
 internet-identity-playwright
-icp-sdk-js-core
 journald-parser
 keysmith
 linkedup


### PR DESCRIPTION
The `agent-js` repo has been renamed to [icp-sdk-js-core](https://github.com/dfinity/icp-sdk-js-core)