### PR TITLE
Add motoko-identity-attributes

### DIFF
--- a/open-repositories.txt
+++ b/open-repositories.txt
@@ -71,6 +71,7 @@ motoko-base
 motoko-bitcoin
 motoko-core
 motoko-dev-server
+motoko-identity-attributes
 motoko-playground
 motoko.rs
 node-motoko


### PR DESCRIPTION
Adds `motoko-identity-attributes` to the open-repositories list so that external contributors can submit PRs to it under the CLA workflow.

The repo is a Motoko library that ships II attribute verification for relying-party canisters. It just landed publish-readiness changes (#16) and is being prepared for a `mops.one` release; CODEOWNERS is in place (#18). External contributions are wanted.